### PR TITLE
Added ability to clear cache

### DIFF
--- a/ckanext/drupal_menu_sync/controller.py
+++ b/ckanext/drupal_menu_sync/controller.py
@@ -1,15 +1,24 @@
-import ckan.plugins.toolkit as tk
-from ckan.controllers.package import PackageController
+import ckan.lib.base as base
+import ckan.lib.helpers as h
+from ckan.controllers.admin import AdminController
 
 from ckanext.drupal_menu_sync.plugin import cache, menu_links
 
+request = base.request
 
-class MainController(PackageController):
+
+class SyncAdmController(AdminController):
 
     def manage_cache(self):
         extra_vars = {}
-        return tk.render('admin/manage_cache.html', extra_vars)
+        if not request.params:
+            return base.render('admin/manage_cache.html', extra_vars)
+        else:
+            if 'clear-main-menu-cache' in request.params:
+                cache.invalidate(menu_links, 'main_menu', 'main')
 
-    def clear_cache(self):
-        cache.invalidate(menu_links, 'main_menu', 'main')
-        return tk.redirect_to('manage_cache')
+            ctrl = 'ckanext.drupal_menu_sync.controller:SyncAdmController'
+            h.redirect_to(
+                controller=ctrl,
+                action='manage_cache'
+            )

--- a/ckanext/drupal_menu_sync/controller.py
+++ b/ckanext/drupal_menu_sync/controller.py
@@ -1,0 +1,15 @@
+import ckan.plugins.toolkit as tk
+from ckan.controllers.package import PackageController
+
+from ckanext.drupal_menu_sync.plugin import cache, menu_links
+
+
+class MainController(PackageController):
+
+    def manage_cache(self):
+        extra_vars = {}
+        return tk.render('admin/manage_cache.html', extra_vars)
+
+    def clear_cache(self):
+        cache.invalidate(menu_links, 'main_menu', 'main')
+        return tk.redirect_to('manage_cache')

--- a/ckanext/drupal_menu_sync/plugin.py
+++ b/ckanext/drupal_menu_sync/plugin.py
@@ -57,16 +57,11 @@ class Drupal_Menu_SyncPlugin(plugins.SingletonPlugin):
 
     def before_map(self, map):
         map.connect(
-            'manage_cache',
-            '/ckan-admin/manage-cache',
-            controller='ckanext.drupal_menu_sync.controller:MainController',
+            'drupal_menu_sync_admin',
+            '/ckan-admin/drupal_menu_sync_admin',
+            controller='ckanext.drupal_menu_sync.controller:SyncAdmController',
             action='manage_cache',
             ckan_icon='file-text'
-        )
-        map.connect(
-            '/ckan-admin/clear-cache',
-            controller='ckanext.drupal_menu_sync.controller:MainController',
-            action='clear_cache'
         )
         return map
 
@@ -75,6 +70,9 @@ class Drupal_Menu_SyncPlugin(plugins.SingletonPlugin):
         toolkit.add_template_directory(config_, 'templates')
         toolkit.add_public_directory(config_, 'public')
         toolkit.add_resource('fanstatic', 'drupal_menu_sync')
+        toolkit.add_ckan_admin_tab(
+            config_, 'drupal_menu_sync_admin', 'Manage Menu sync'
+        )
 
     # ITemplateHelpers
     def get_helpers(self):

--- a/ckanext/drupal_menu_sync/plugin.py
+++ b/ckanext/drupal_menu_sync/plugin.py
@@ -1,23 +1,24 @@
-import routes
 import requests
-import urlparse
+import logging
+
 from pylons import config
+from beaker.cache import CacheManager
+
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
-from pylons.decorators.cache import beaker_cache
-import logging
-import json
-import re
-from ckan.common import _, g
 import ckan.lib.helpers as h
 
 log = logging.getLogger(__name__)
+cache = CacheManager()
 
-@beaker_cache(expire=3600)
+
+@cache.cache('main_menu', expire=3600)
 def menu_links(section=None):
     drupal_url = config.get('drupal.site_url')
-    if drupal_url == None or drupal_url == h.full_current_url().split('?')[0][:-1]:
-      return None
+    if drupal_url is None or (
+        drupal_url == h.full_current_url().split('?')[0][:-1]
+    ):
+        return None
     # request links from Drupal
     r = None
     section_menu = []
@@ -31,23 +32,43 @@ def menu_links(section=None):
         log.error(e.message)
 
     if r:
-      links = r.json()
+        links = r.json()
     else:
-      return None
-    if links:
-      if section in links:
-        if section == 'main':
-            for item in links[section]:
-                if item['link'] == '<front>':
-                    item['link'] = drupal_url
-        section_menu.extend(links[section])
-        return section_menu
-      else:
         return None
+
+    if links:
+        if section in links:
+            if section == 'main':
+                for item in links[section]:
+                    if item['link'] == '<front>':
+                        item['link'] = drupal_url
+            section_menu.extend(links[section])
+            return section_menu
+        else:
+            return None
+
 
 class Drupal_Menu_SyncPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.ITemplateHelpers)
+    plugins.implements(plugins.IRoutes, inherit=True)
+
+    # IRoutes
+
+    def before_map(self, map):
+        map.connect(
+            'manage_cache',
+            '/ckan-admin/manage-cache',
+            controller='ckanext.drupal_menu_sync.controller:MainController',
+            action='manage_cache',
+            ckan_icon='file-text'
+        )
+        map.connect(
+            '/ckan-admin/clear-cache',
+            controller='ckanext.drupal_menu_sync.controller:MainController',
+            action='clear_cache'
+        )
+        return map
 
     # IConfigurer
     def update_config(self, config_):
@@ -57,6 +78,6 @@ class Drupal_Menu_SyncPlugin(plugins.SingletonPlugin):
 
     # ITemplateHelpers
     def get_helpers(self):
-      return {
-        'menu_links': menu_links
+        return {
+            'menu_links': menu_links
         }

--- a/ckanext/drupal_menu_sync/templates/admin/base.html
+++ b/ckanext/drupal_menu_sync/templates/admin/base.html
@@ -1,0 +1,6 @@
+{% ckan_extends %}
+
+{% block content_primary_nav %}
+   {{ super() }}
+   {{ h.build_nav_icon('manage_cache', _('Manage Cache')) }}
+{% endblock %}

--- a/ckanext/drupal_menu_sync/templates/admin/base.html
+++ b/ckanext/drupal_menu_sync/templates/admin/base.html
@@ -1,6 +1,0 @@
-{% ckan_extends %}
-
-{% block content_primary_nav %}
-   {{ super() }}
-   {{ h.build_nav_icon('manage_cache', _('Manage Cache')) }}
-{% endblock %}

--- a/ckanext/drupal_menu_sync/templates/admin/manage_cache.html
+++ b/ckanext/drupal_menu_sync/templates/admin/manage_cache.html
@@ -1,0 +1,16 @@
+{% extends "admin/base.html" %} 
+
+{% block primary_content_inner %}
+  {% link_for _('Clear cache'), controller='ckanext.drupal_menu_sync.controller:MainController', action='clear_cache', class_='btn btn-primary' %}
+{% endblock %} 
+
+{% block secondary_content %}
+<div class="module module-narrow module-shallow">
+  <h2 class="module-heading">
+    <i class="icon-info-sign"></i>
+    {{ _('Manage Cache') }}
+  </h2>
+  <div class="module-content">
+  </div>
+</div>
+{% endblock %}

--- a/ckanext/drupal_menu_sync/templates/admin/manage_cache.html
+++ b/ckanext/drupal_menu_sync/templates/admin/manage_cache.html
@@ -1,16 +1,26 @@
 {% extends "admin/base.html" %} 
 
 {% block primary_content_inner %}
-  {% link_for _('Clear cache'), controller='ckanext.drupal_menu_sync.controller:MainController', action='clear_cache', class_='btn btn-primary' %}
+  <p>Clear cache for the <b>main</b> (top) menu</p>
+  <form method="POST" id="clear-main-menu-cache">
+      <button
+        type="submit"
+        name="clear-main-menu-cache"
+        value="clear_cache"
+        class="btn btn-primary"
+        >Clear cache</button>
+    </form>
+  <hr />
 {% endblock %} 
 
 {% block secondary_content %}
 <div class="module module-narrow module-shallow">
   <h2 class="module-heading">
-    <i class="icon-info-sign"></i>
-    {{ _('Manage Cache') }}
+    <i class="fa fa-info-circle"></i>
+    {{ _('Menu synchronization') }}
   </h2>
   <div class="module-content">
+    Here is you can manage menu synchronization with Drupal
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
To admin page added 'Manage Cache' tab. It has a button to Clear cache. We need it because if admin change menu on the Drupal side, we can't see changes until the cache expires.
Also made small code improvements.